### PR TITLE
fix(headers): stop the catch-all leaking into the icon cache rule

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,24 +1,35 @@
-# Cloudflare Pages applies every matching rule in order, so the catch-all goes
-# first and the more specific rules below override it.
+# Cloudflare Pages CONCATENATES values when several rules set the same header —
+# it does not let a later rule override an earlier one. A /* catch-all setting
+# Cache-Control therefore leaks into every specific rule below it, producing
+# "no-store, ..., max-age=31536000, immutable" and no caching at all.
+# So: security headers on /*, and Cache-Control only on non-overlapping paths.
 
-# Default: never serve a stale app shell. LINE Browser holds onto old copies
-# aggressively and users end up running last week's JavaScript.
 /*
-  Cache-Control: no-cache, no-store, must-revalidate
-  Pragma: no-cache
-  Expires: 0
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
 
-# The service worker controls what everyone else sees — it must never be stale.
+# The app shell must never be stale. LINE Browser holds onto old copies
+# aggressively and users end up running last week's JavaScript.
+/
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+/index.html
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+/test-location.html
+  Cache-Control: no-cache, no-store, must-revalidate
+
+# The service worker controls what everyone else sees — never serve it stale.
 /sw.js
   Cache-Control: no-cache, no-store, must-revalidate
 
 # Icons never change without changing name, so let the browser keep them.
 /icons/*
   Cache-Control: public, max-age=31536000, immutable
-  Pragma: cache
 
 /manifest.json
   Cache-Control: public, max-age=86400
-  Pragma: cache


### PR DESCRIPTION
Refs #6

ตรวจ header ของเว็บที่ deploy จริงหลัง merge #12 แล้วเจอว่า `_headers` ไม่ทำงานตามที่ตั้งใจ

```
$ curl -I https://location-share.pages.dev/icons/icon-192.png
cache-control: no-cache, no-store, must-revalidate, public, max-age=31536000, immutable
```

Cloudflare Pages **ต่อค่า** เมื่อมีหลายกฎตั้ง header เดียวกัน ไม่ได้ให้กฎที่เฉพาะเจาะจงกว่าชนะ
กฎ `/*` จึงรั่วเข้าไปในทุกกฎที่อยู่ล่างกว่า และ `no-store` ชนะ = icon ไม่ถูก cache เลย
ตรงข้ามกับที่ตั้งใจ

แก้โดยให้ `/*` เหลือแค่ security header ที่ตั้งใจให้ครอบทุกที่จริงๆ ส่วน `Cache-Control`
ระบุเฉพาะ path ที่ไม่ทับกัน และไล่ HTML ทีละไฟล์แทนการพึ่ง catch-all

ไม่กระทบพฤติกรรมของ app shell — ยังเป็น `no-store` เหมือนเดิม เปลี่ยนแค่ให้ icon
กับ manifest ถูก cache ได้จริง