### PR TITLE
feat(auth): give every device an anonymous identity (phase 1 of #3)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -86,24 +86,34 @@ SQL พร้อมรันอยู่ที่ [`migrate-rls-owner.sql`](migr
 
 **สิ่งที่ต้องแลก:**
 
-1. ต้องเปิด Anonymous Sign-ins ใน Dashboard ก่อน (Authentication → Providers)
-2. ต้อง deploy client ที่เรียก `auth.signInAnonymously()` **พร้อมกัน** กับการรัน SQL
-   ไม่งั้น client เดิมจะเขียนข้อมูลไม่ได้เลย
-3. ทุกเครื่องที่เปิดแอปจะสร้างแถวใน `auth.users` และไม่หายเอง ต้องตั้ง cron ล้าง
-4. ถ้าผู้ใช้ล้าง site data จะกลายเป็นคนละ identity — หมุดเก่าที่ตัวเองสร้างจะลบไม่ได้อีก
+1. ต้องเปิด Anonymous Sign-ins ใน Dashboard (Authentication → Providers)
+2. ทุกเครื่องที่เปิดแอปจะสร้างแถวใน `auth.users` และไม่หายเอง
+3. ถ้าผู้ใช้ล้าง site data จะกลายเป็นคนละ identity — หมุดเก่าที่ตัวเองสร้างจะลบไม่ได้อีก
    (จึงยังเปิด DELETE ของ routes/pins ให้คนในห้องไว้ตามเดิม)
 
-โค้ดฝั่ง client ที่ต้องเพิ่ม:
+### ทำเป็นสองขั้น ไม่ต้องกดพร้อมกัน
 
-```js
-// ต้องรอให้ session พร้อมก่อนยิง query แรก
-const { error: authError } = await supabaseClient.auth.signInAnonymously();
-if (authError) console.error('Anonymous sign-in failed:', authError);
-```
+เอกสารฉบับก่อนบอกว่าต้อง deploy client กับรัน SQL พร้อมกัน — ไม่จำเป็นครับ
+ทำเรียงกันได้และปลอดภัยกว่า เพราะ **ขั้นที่ 1 ปลอดภัยไม่ว่า policy จะรัดหรือยัง**
 
-> ยังไม่ได้ใส่ไว้ใน `index.html` เพราะถ้า deploy ออกไปตอนที่ยังไม่ได้เปิด
-> Anonymous Sign-ins ในโปรเจกต์ แอปจะพังทั้งตัว — เป็นการตัดสินใจที่ต้องทำพร้อมกัน
-> ทั้งฝั่ง Dashboard และฝั่ง deploy
+| ขั้น | ทำอะไร | ถ้าหยุดตรงนี้ |
+|---|---|---|
+| 0 | เปิด provider ใน Dashboard | ไม่มีผลกับใคร |
+| 1 | deploy client ที่ `signInAnonymously()` | policy ยังหลวม ทุกอย่างทำงานปกติ แต่ทุกเครื่องเริ่มมี identity |
+| 2 | รัน SQL รัดกุม policy | client มี session อยู่แล้ว → เขียนผ่านทันที |
+
+**ขั้น 1 ทำแล้ว** — `ensureSession()` ใน `index.html` ยิง `signInAnonymously()` ตอน boot
+โดยไม่ block การอ่าน (อ่านเป็น public อยู่แล้ว) ส่วนการเขียนทุกจุดผ่าน `withSession()`
+ซึ่งถ้าเจอ session หมดอายุหรือถูกลบ จะ re-auth เงียบๆ แล้วลองใหม่หนึ่งครั้ง
+ก่อนจะโยน error ให้ผู้ใช้เห็น
+
+ถ้า provider ยังไม่เปิด `ensureSession()` จะ log error แล้วปล่อยผ่าน แอปยังทำงานได้
+ตามปกติ — จึง deploy ขั้น 1 ไปก่อนได้โดยไม่ต้องรอ
+
+**ขั้น 2 ยังไม่ทำ** — SQL อยู่ที่ [`migrate-rls-owner.sql`](migrate-rls-owner.sql)
+
+> ระหว่างขั้น 1 กับขั้น 2 ใครที่เปิดแอปค้างไว้ตั้งแต่ก่อนขั้น 1 จะเขียนไม่ได้หลังขั้น 2
+> จนกว่าจะโหลดหน้าใหม่ ตำแหน่งหมดอายุใน 15 นาทีอยู่แล้ว จึงไม่มีข้อมูลไหนค้าง
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -581,6 +581,66 @@
       alert('Supabase init error: ' + e.message);
     }
 
+    // --- Anonymous identity ---
+    // Without a session every caller is the same `anon` role, so the database
+    // cannot tell one device's rows from another's and RLS can only be all or
+    // nothing. An anonymous sign-in costs the user nothing — no prompt, no
+    // account — but gives each device a real auth.uid() for policies to key on.
+    //
+    // Started here rather than awaited: reads are public, so the map can paint
+    // while this is in flight. Writers await sessionReady before touching a table.
+    let sessionReady = null;
+
+    async function ensureSession() {
+      if (!supabaseClient) return null;
+      try {
+        const { data: { session } } = await supabaseClient.auth.getSession();
+        if (session) return session;
+
+        const { data, error } = await supabaseClient.auth.signInAnonymously();
+        if (error) {
+          console.error('Anonymous sign-in failed:', error);
+          return null;
+        }
+        return data.session;
+      } catch (e) {
+        console.error('Anonymous sign-in threw:', e);
+        return null;
+      }
+    }
+
+    function isAuthError(error) {
+      if (!error) return false;
+      // 42501 is Postgres "insufficient privilege", which is what an RLS
+      // rejection looks like from the client side.
+      if (error.code === '42501' || error.code === 'PGRST301') return true;
+      const text = `${error.code || ''} ${error.message || ''}`.toLowerCase();
+      return text.includes('jwt')
+        || text.includes('row-level security')
+        || text.includes('not authenticated');
+    }
+
+    // Supabase can hand back a session that has expired, or whose anonymous user
+    // was purged. One silent re-auth and retry beats showing the user a
+    // row-level-security error they can do nothing about.
+    async function withSession(run) {
+      await sessionReady;
+      let result = await run();
+      if (isAuthError(result && result.error)) {
+        try { await supabaseClient.auth.signOut(); } catch (e) {}
+        if (await ensureSession()) result = await run();
+      }
+      return result;
+    }
+
+    // For writes that must not proceed without an identity at all.
+    async function requireSession() {
+      if (await sessionReady) return true;
+      if (await ensureSession()) return true;
+      alert('เชื่อมต่อระบบยืนยันตัวตนไม่สำเร็จ\nกรุณาโหลดหน้านี้ใหม่แล้วลองอีกครั้ง');
+      return false;
+    }
+
     // --- Group/Room from URL hash (supports Thai) ---
     const MAX_ROOM_LEN = 64;
 
@@ -675,10 +735,14 @@
 
     async function startSharing() {
       if (!supabaseClient) return alert('Supabase client not initialized');
-      
+
       const displayName = document.getElementById('displayName').value.trim();
       if (!displayName) return alert('กรุณาใส่ชื่อของคุณก่อนแชร์ตำแหน่ง');
       localStorage.setItem('display_name', displayName);
+
+      // Fail here, before the GPS prompt, rather than silently dropping every
+      // position update once watchPosition is running.
+      if (!await requireSession()) return;
 
       if (!navigator.geolocation) return alert('เบราว์เซอร์ไม่รองรับ Geolocation');
       
@@ -726,7 +790,7 @@
         }
 
         // Send to Supabase
-        const { error } = await supabaseClient
+        const { error } = await withSession(() => supabaseClient
           .from('locations')
           .upsert({
             user_id: userId,
@@ -734,7 +798,7 @@
             lat: latitude,
             lng: longitude,
             display_name: displayName
-          }, { onConflict: 'user_id,room' });
+          }, { onConflict: 'user_id,room' }));
 
         if (error) console.error('Upsert error:', error);
     }
@@ -760,11 +824,11 @@
       isSharing = false;
       updateShareButtonUI();
 
-      const { error } = await supabaseClient
+      const { error } = await withSession(() => supabaseClient
         .from('locations')
         .delete()
         .eq('user_id', userId)
-        .eq('room', getRoom());
+        .eq('room', getRoom()));
 
       if (error) {
         console.error('Stop share error:', error);
@@ -1116,7 +1180,7 @@
 
       const color = ROUTE_COLORS[routeData.length % ROUTE_COLORS.length];
 
-      const { error } = await supabaseClient
+      const { error } = await withSession(() => supabaseClient
         .from('routes')
         .insert({
           room: getRoom(),
@@ -1124,7 +1188,7 @@
           coordinates: latlngs,
           color: color,
           created_by: userId
-        });
+        }));
 
       if (error) {
         console.error('Save route error:', error);
@@ -1182,7 +1246,8 @@
 
     async function deleteRoute(id) {
       if (!confirm('ลบเส้นทางนี้?')) return;
-      const { error } = await supabaseClient.from('routes').delete().eq('id', id);
+      const { error } = await withSession(() =>
+        supabaseClient.from('routes').delete().eq('id', id));
       if (error) console.error('Delete route error:', error);
     }
 
@@ -1291,7 +1356,7 @@
         return;
       }
 
-      const { error } = await supabaseClient
+      const { error } = await withSession(() => supabaseClient
         .from('pins')
         .insert({
           room: getRoom(),
@@ -1300,7 +1365,7 @@
           lng: latlng.lng,
           icon: safeIcon(result.icon),
           created_by: userId
-        });
+        }));
 
       if (error) {
         console.error('Save pin error:', error);
@@ -1364,7 +1429,8 @@
 
     async function deletePin(id) {
       if (!confirm('ลบหมุดนี้?')) return;
-      const { error } = await supabaseClient.from('pins').delete().eq('id', id);
+      const { error } = await withSession(() =>
+        supabaseClient.from('pins').delete().eq('id', id));
       if (error) console.error('Delete pin error:', error);
     }
 
@@ -1437,6 +1503,11 @@
     // ===== Boot =====
     // Everything starts here, at the very bottom, so no init path can run
     // before the state it depends on has been declared.
+
+    // Kick off, do not await: reads are public, so the map paints immediately
+    // and only writers block on this.
+    sessionReady = ensureSession();
+
     try {
       subscribeToLocations();
     } catch (e) {

--- a/tests/smoke.js
+++ b/tests/smoke.js
@@ -82,11 +82,28 @@ const query = new Proxy({}, {
   },
 });
 const channel = { on: () => channel, subscribe: () => channel };
+
+// Anonymous auth stub. authCalls lets the checks below assert that the app
+// reuses an existing session instead of minting a user on every page load.
+const authCalls = { getSession: 0, signInAnonymously: 0, signOut: 0 };
+let storedSession = null;
+
+const auth = {
+  getSession: async () => { authCalls.getSession++; return { data: { session: storedSession } }; },
+  signInAnonymously: async () => {
+    authCalls.signInAnonymously++;
+    storedSession = { user: { id: '00000000-0000-4000-8000-000000000001', is_anonymous: true } };
+    return { data: { session: storedSession }, error: null };
+  },
+  signOut: async () => { authCalls.signOut++; storedSession = null; return { error: null }; },
+};
+
 const supabase = {
   createClient: () => ({
     from: () => query,
     channel: () => channel,
     removeChannel: () => {},
+    auth,
   }),
 };
 
@@ -170,11 +187,68 @@ if (!failed) {
   }
 }
 
-if (missing.length) {
-  console.log('❌ getElementById on ids not present in markup: ' + [...new Set(missing)].join(', '));
-  failed = true;
-} else {
-  console.log('✅ every getElementById target exists in the markup');
+// Auth behaviour is async, so it runs after the synchronous checks above.
+async function authChecks() {
+  const results = [];
+  const t = (name, ok) => results.push([name, ok]);
+
+  // Boot deliberately does not await its sign-in, and top-level `let` bindings
+  // are not properties of the vm global, so the promise cannot be reached from
+  // out here. Drain the microtask queue instead — the auth stubs resolve
+  // immediately, so one macrotask boundary is enough to settle the whole chain.
+  const settle = () => new Promise(resolve => setImmediate(resolve));
+  await settle();
+  await settle();
+
+  // Exactly one: a second sign-in per load would mint a second anonymous user
+  // in auth.users every time anyone opens the app.
+  t('boot signed in anonymously exactly once', authCalls.signInAnonymously === 1);
+
+  const before = authCalls.signInAnonymously;
+  await sandbox.ensureSession();
+  t('an existing session is reused, not replaced', authCalls.signInAnonymously === before);
+
+  t('requireSession passes once signed in', await sandbox.requireSession() === true);
+
+  // RLS rejections arrive as ordinary error objects; they must be recognised
+  // so the retry path fires instead of the user seeing a Postgres error.
+  t('RLS rejection counts as an auth error',
+    sandbox.isAuthError({ code: '42501', message: 'new row violates row-level security policy' }) === true);
+  t('expired JWT counts as an auth error',
+    sandbox.isAuthError({ message: 'JWT expired' }) === true);
+  t('a constraint violation does not',
+    sandbox.isAuthError({ code: '23514', message: 'violates check constraint' }) === false);
+  t('no error is not an auth error', sandbox.isAuthError(null) === false);
+
+  // A stale session must cost one silent re-auth and a retry, not a visible failure.
+  const signOutsBefore = authCalls.signOut;
+  let attempts = 0;
+  const res = await sandbox.withSession(async () => {
+    attempts++;
+    return attempts === 1
+      ? { error: { code: '42501', message: 'row-level security' } }
+      : { error: null, data: [] };
+  });
+  t('a stale session is retried once and succeeds', attempts === 2 && !res.error);
+  t('the retry signed out first', authCalls.signOut === signOutsBefore + 1);
+
+  return results;
 }
 
-process.exit(failed ? 1 : 0);
+(async () => {
+  if (!failed) {
+    for (const [name, ok] of await authChecks()) {
+      console.log((ok ? '  ✅ ' : '  ❌ ') + name);
+      if (!ok) failed = true;
+    }
+  }
+
+  if (missing.length) {
+    console.log('❌ getElementById on ids not present in markup: ' + [...new Set(missing)].join(', '));
+    failed = true;
+  } else {
+    console.log('✅ every getElementById target exists in the markup');
+  }
+
+  process.exit(failed ? 1 : 0);
+})();


### PR DESCRIPTION
Refs #3 — ขั้นที่ 1 จากสองขั้น ยังไม่แตะ RLS policy

## ทำไมต้องมี identity ก่อน

ตอนนี้ทุก request มาถึง database ในฐานะ role `anon` เหมือนกันหมด database จึงแยกไม่ออกว่า
แถวไหนของใคร RLS เลยเขียนได้แค่ "เปิดให้ทุกคน" หรือ "ปิดทุกคน" — ซึ่งเป็นสาเหตุที่
ใครถือ anon key (ซึ่งอยู่ใน source ของหน้าเว็บ) ก็ลบข้อมูลคนอื่นได้

Anonymous sign-in ไม่มี prompt ไม่มีบัญชี ผู้ใช้ไม่รู้สึกอะไรเลย แต่ทำให้แต่ละเครื่อง
มี `auth.uid()` จริงให้ policy เกาะได้

## แก้แผนจากที่เอกสารเคยเขียนไว้

`SECURITY.md` เดิมบอกว่าต้อง deploy client กับรัน SQL **พร้อมกัน** — ไม่จำเป็นครับ

| ขั้น | ทำอะไร | ถ้าหยุดตรงนี้ |
|---|---|---|
| 0 | เปิด provider ใน Dashboard | ไม่มีผลกับใคร |
| **1** | **PR นี้** — client `signInAnonymously()` | policy ยังหลวม ทุกอย่างทำงานปกติ |
| 2 | รัน SQL รัดกุม policy | client มี session อยู่แล้ว เขียนผ่านทันที |

กุญแจคือขั้น 1 ปลอดภัยเสมอ ไม่ว่า policy จะรัดหรือยัง เลยไม่ต้องกดพร้อมกันให้เสี่ยง

**PR นี้ deploy ได้เลยแม้ยังไม่ได้เปิด provider** — `ensureSession()` จะ log error
แล้วปล่อยผ่าน แอปทำงานตามเดิมทุกอย่าง

## รายละเอียด

- boot ยิง sign-in โดย **ไม่ await** เพราะการอ่านเป็น public อยู่แล้ว แผนที่จึงขึ้นทันที
  มีแต่การเขียนที่รอ session
- การเขียนทุกจุดผ่าน `withSession()` ถ้าเจอ session หมดอายุหรือ anonymous user
  ถูกลบไปแล้ว จะ re-auth เงียบๆ แล้วลองใหม่หนึ่งครั้ง ไม่โยน error RLS ให้ผู้ใช้เห็น
- `startSharing()` เช็ค session **ก่อน** ขอสิทธิ์ GPS จะได้ไม่ปล่อยให้ `watchPosition`
  วิ่งแล้วเขียนไม่ลงเงียบๆ

## เทสต์

เพิ่มใน `tests/smoke.js` — sign-in ครั้งเดียวต่อการโหลด (ถ้าสองครั้งจะสร้าง user
ส่วนเกินใน `auth.users` ทุกครั้งที่มีคนเปิดแอป), ใช้ session เดิมซ้ำ,
แยก RLS rejection ออกจาก constraint violation, และ retry ทำงานจริง

ทดสอบว่าเทสต์จับ regression ได้จริงด้วยการทำลายทีละจุดแล้วดูว่ามันแดง